### PR TITLE
[FEATURE #3]: 기본 Member 엔티티 및 JWT 인증 관련 클래스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/FinTo/domain/member/Member.java
+++ b/src/main/java/FinTo/domain/member/Member.java
@@ -1,14 +1,25 @@
 package FinTo.domain.member;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class Member {
     @Id
     @GeneratedValue
     private Long id;
     @Enumerated(EnumType.STRING)
     private MemberRole role;
+    private String name;
+
+    public static Member create(String name) {
+        return Member.builder()
+                .role(MemberRole.MEMBER)
+                .name(name)
+                .build();
+    }
 }

--- a/src/main/java/FinTo/domain/member/Member.java
+++ b/src/main/java/FinTo/domain/member/Member.java
@@ -1,8 +1,6 @@
 package FinTo.domain.member;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
@@ -11,4 +9,6 @@ public class Member {
     @Id
     @GeneratedValue
     private Long id;
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
 }

--- a/src/main/java/FinTo/domain/member/Member.java
+++ b/src/main/java/FinTo/domain/member/Member.java
@@ -1,0 +1,14 @@
+package FinTo.domain.member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+    @Id
+    @GeneratedValue
+    private Long id;
+}

--- a/src/main/java/FinTo/domain/member/MemberRepository.java
+++ b/src/main/java/FinTo/domain/member/MemberRepository.java
@@ -2,5 +2,10 @@ package FinTo.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByName(String name);
+
+    Optional<Member> findByName(String name);
 }

--- a/src/main/java/FinTo/domain/member/MemberRepository.java
+++ b/src/main/java/FinTo/domain/member/MemberRepository.java
@@ -1,0 +1,6 @@
+package FinTo.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/FinTo/domain/member/MemberRole.java
+++ b/src/main/java/FinTo/domain/member/MemberRole.java
@@ -1,0 +1,5 @@
+package FinTo.domain.member;
+
+public enum MemberRole {
+    MEMBER,
+}

--- a/src/main/java/FinTo/global/dev/DevInitializer.java
+++ b/src/main/java/FinTo/global/dev/DevInitializer.java
@@ -1,0 +1,49 @@
+package FinTo.global.dev;
+
+import FinTo.domain.member.Member;
+import FinTo.domain.member.MemberRepository;
+import FinTo.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * dev 프로필에서만 테스트용 데이터를 자동으로 넣기 위한 컴포넌트입니다.
+ * 필요한 경우 application.properties 에서 spring.profiles.active=dev 를 추가하여
+ * 사용할 수 있습니다.
+ */
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+@Slf4j
+public class DevInitializer implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    @Override
+    public void run(String... args) throws Exception {
+        Member dev = memberRepository.findByName("dev")
+                .orElseGet(() -> {
+                    Member member = Member.create("dev");
+                    memberRepository.save(member);
+                    log.info("개발용 Member 생성: id={}, name={}",
+                            member.getId(), member.getName());
+                    return member;
+                });
+
+        String accessToken = jwtTokenProvider.createAccessToken(dev.getId());
+
+        log.info("""
+                
+                ==================== [Dev Access Token] ====================
+                {}
+                ============================================================
+                """,
+                accessToken
+        );
+    }
+}

--- a/src/main/java/FinTo/global/error/BaseException.java
+++ b/src/main/java/FinTo/global/error/BaseException.java
@@ -1,0 +1,13 @@
+package FinTo.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/FinTo/global/error/ErrorCode.java
+++ b/src/main/java/FinTo/global/error/ErrorCode.java
@@ -1,0 +1,15 @@
+package FinTo.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    JWT_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "JWT 인증에 실패하였습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/FinTo/global/error/ErrorCode.java
+++ b/src/main/java/FinTo/global/error/ErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     JWT_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "JWT 인증에 실패하였습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
 

--- a/src/main/java/FinTo/global/error/ErrorResponse.java
+++ b/src/main/java/FinTo/global/error/ErrorResponse.java
@@ -1,0 +1,28 @@
+package FinTo.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+    private final String path;
+    @Builder.Default
+    private final LocalDateTime timestamp = LocalDateTime.now();
+
+    public static ResponseEntity<ErrorResponse> create(ErrorCode code, String path) {
+        return ResponseEntity.status(code.getStatus()).body(
+                ErrorResponse.builder()
+                        .code(code.toString())
+                        .message(code.getMessage())
+                        .path(path)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/FinTo/global/error/ErrorResponse.java
+++ b/src/main/java/FinTo/global/error/ErrorResponse.java
@@ -3,10 +3,12 @@ package FinTo.global.error;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
 
+@Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
@@ -16,7 +18,7 @@ public class ErrorResponse {
     @Builder.Default
     private final LocalDateTime timestamp = LocalDateTime.now();
 
-    public static ResponseEntity<ErrorResponse> create(ErrorCode code, String path) {
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode code, String path) {
         return ResponseEntity.status(code.getStatus()).body(
                 ErrorResponse.builder()
                         .status(code.toString())
@@ -24,5 +26,13 @@ public class ErrorResponse {
                         .path(path)
                         .build()
         );
+    }
+
+    public static ErrorResponse create(ErrorCode code, String path) {
+        return ErrorResponse.builder()
+                .status(code.toString())
+                .error(code.getMessage())
+                .path(path)
+                .build();
     }
 }

--- a/src/main/java/FinTo/global/error/ErrorResponse.java
+++ b/src/main/java/FinTo/global/error/ErrorResponse.java
@@ -10,8 +10,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
-    private final String code;
-    private final String message;
+    private final String status;
+    private final String error;
     private final String path;
     @Builder.Default
     private final LocalDateTime timestamp = LocalDateTime.now();
@@ -19,8 +19,8 @@ public class ErrorResponse {
     public static ResponseEntity<ErrorResponse> create(ErrorCode code, String path) {
         return ResponseEntity.status(code.getStatus()).body(
                 ErrorResponse.builder()
-                        .code(code.toString())
-                        .message(code.getMessage())
+                        .status(code.toString())
+                        .error(code.getMessage())
                         .path(path)
                         .build()
         );

--- a/src/main/java/FinTo/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/FinTo/global/error/GlobalExceptionHandler.java
@@ -14,12 +14,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException e, HttpServletRequest request) {
         log.info("BaseException 발생: 요청 [{}], 코드 [{}], 메시지 [{}]",
                 request.getRequestURI(), e.getErrorCode(), e.getMessage());
-        return ErrorResponse.create(e.getErrorCode(), request.getRequestURI());
+        return ErrorResponse.toResponseEntity(e.getErrorCode(), request.getRequestURI());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.error("예기치 못한 예외 발생: 요청 [{}]", request.getRequestURI(), e);
-        return ErrorResponse.create(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+        return ErrorResponse.toResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
     }
 }

--- a/src/main/java/FinTo/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/FinTo/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package FinTo.global.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e, HttpServletRequest request) {
+        log.info("BaseException 발생: 요청 [{}], 코드 [{}], 메시지 [{}]",
+                request.getRequestURI(), e.getErrorCode(), e.getMessage());
+        return ErrorResponse.create(e.getErrorCode(), request.getRequestURI());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        log.error("예기치 못한 예외 발생: 요청 [{}]", request.getRequestURI(), e);
+        return ErrorResponse.create(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+    }
+}

--- a/src/main/java/FinTo/global/security/SecurityConfig.java
+++ b/src/main/java/FinTo/global/security/SecurityConfig.java
@@ -2,17 +2,28 @@ package FinTo.global.security;
 
 import FinTo.global.security.handler.CustomAccessDeniedHandler;
 import FinTo.global.security.handler.CustomAuthenticationEntryPoint;
+import FinTo.global.security.jwt.JwtAuthenticationFilter;
+import FinTo.global.security.jwt.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -28,10 +39,21 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
                 .exceptionHandling(configurer -> configurer
                         .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                         .accessDeniedHandler(new CustomAccessDeniedHandler())
                 )
                 .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(jwtAuthenticationProvider);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(authenticationManager());
     }
 }

--- a/src/main/java/FinTo/global/security/SecurityConfig.java
+++ b/src/main/java/FinTo/global/security/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -24,6 +23,8 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -41,8 +42,8 @@ public class SecurityConfig {
                 )
                 .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
                 .exceptionHandling(configurer -> configurer
-                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-                        .accessDeniedHandler(new CustomAccessDeniedHandler())
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
                 )
                 .build();
     }

--- a/src/main/java/FinTo/global/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/FinTo/global/security/exception/JwtAuthenticationException.java
@@ -1,0 +1,10 @@
+package FinTo.global.security.exception;
+
+import FinTo.global.error.BaseException;
+import FinTo.global.error.ErrorCode;
+
+public class JwtAuthenticationException extends BaseException {
+    public JwtAuthenticationException() {
+        super(ErrorCode.JWT_AUTHENTICATION_FAIL);
+    }
+}

--- a/src/main/java/FinTo/global/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/FinTo/global/security/exception/JwtAuthenticationException.java
@@ -1,10 +1,13 @@
 package FinTo.global.security.exception;
 
-import FinTo.global.error.BaseException;
 import FinTo.global.error.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
 
-public class JwtAuthenticationException extends BaseException {
-    public JwtAuthenticationException() {
-        super(ErrorCode.JWT_AUTHENTICATION_FAIL);
+public class JwtAuthenticationException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public JwtAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/FinTo/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/FinTo/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,17 +1,31 @@
 package FinTo.global.security.handler;
 
+import FinTo.global.error.ErrorCode;
+import FinTo.global.error.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorResponse errorResponse = ErrorResponse.create(ErrorCode.ACCESS_DENIED, request.getRequestURI());
+
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationConverter.java
@@ -1,0 +1,26 @@
+package FinTo.global.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationConverter implements AuthenticationConverter {
+
+    @Override
+    public JwtAuthenticationToken convert(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return null;
+        }
+
+        String token = authorizationHeader.substring(7);
+        if (token.isEmpty()) {
+            return null;
+        }
+
+        return JwtAuthenticationToken.unauthenticated(token);
+    }
+}

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             SecurityContextHolder.getContext().setAuthentication(authenticationResult);
         } catch (Exception e) {
-            log.trace("Exception occurred on JwtAuthenticationFilter. This usually means request has proper Bearer header but failed to validate the token. The filter does not throw an exception out of the filter chain but simply delegates the exception strategy to AuthorizationFilter.", e);
+            log.debug("Exception occurred on JwtAuthenticationFilter. This usually means request has proper Bearer header but failed to validate the token. The filter does not throw an exception out of the filter chain but simply delegates the exception strategy to AuthorizationFilter.", e);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package FinTo.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AuthenticationConverter authenticationConverter = new JwtAuthenticationConverter();
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        Authentication authenticationRequest = authenticationConverter.convert(request);
+        if (authenticationRequest == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            Authentication authenticationResult = authenticationManager.authenticate(authenticationRequest);
+            if (authenticationResult == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationResult);
+        } catch (Exception e) {
+            log.trace("Exception occurred on JwtAuthenticationFilter. This usually means request has proper Bearer header but failed to validate the token. The filter does not throw an exception out of the filter chain but simply delegates the exception strategy to AuthorizationFilter.", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
@@ -1,10 +1,6 @@
 package FinTo.global.security.jwt;
 
 import FinTo.global.security.exception.JwtAuthenticationException;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
@@ -12,7 +8,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-import ppalatjyo.server.global.security.exception.JwtValidationException;
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +31,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
                     token,
                     userDetails.getAuthorities());
         } catch (Exception e) { // JwtException을 AuthenticationException 으로 변환
-            throw new JwtAuthenticationException(e);
+            throw new JwtAuthenticationException();
         }
     }
 

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,47 @@
+package FinTo.global.security.jwt;
+
+import FinTo.global.security.exception.JwtAuthenticationException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import ppalatjyo.server.global.security.exception.JwtValidationException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String token = (String) authentication.getCredentials();
+
+        try {
+            jwtTokenProvider.validateToken(token); // 여기서 예외가 발생하면 catch로 넘어감
+
+            String userId = jwtTokenProvider.getUserIdFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userId); // throws UsernameNotFoundException
+
+            return JwtAuthenticationToken.authenticated(
+                    userDetails,
+                    token,
+                    userDetails.getAuthorities());
+        } catch (Exception e) { // JwtException을 AuthenticationException 으로 변환
+            throw new JwtAuthenticationException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationProvider.java
@@ -1,5 +1,6 @@
 package FinTo.global.security.jwt;
 
+import FinTo.global.error.ErrorCode;
 import FinTo.global.security.exception.JwtAuthenticationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -31,7 +32,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
                     token,
                     userDetails.getAuthorities());
         } catch (Exception e) { // JwtException을 AuthenticationException 으로 변환
-            throw new JwtAuthenticationException();
+            throw new JwtAuthenticationException(ErrorCode.JWT_AUTHENTICATION_FAIL);
         }
     }
 

--- a/src/main/java/FinTo/global/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,42 @@
+package FinTo.global.security.jwt;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+    private final String credentials;
+
+    private JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true);
+    }
+
+    private JwtAuthenticationToken(String credentials) {
+        this(null, credentials, null);
+        setAuthenticated(false);
+    }
+
+    public static JwtAuthenticationToken authenticated(Object principal, String token, Collection<? extends GrantedAuthority> authorities) {
+        return new JwtAuthenticationToken(principal, token, authorities);
+    }
+
+    public static JwtAuthenticationToken unauthenticated(String token) {
+        return new JwtAuthenticationToken(token);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+}

--- a/src/main/java/FinTo/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/FinTo/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,69 @@
+package FinTo.global.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    private static final String SECRET_KEY = "my-very-secret-key-that-should-be-at-least-256-bits-long!";
+    private static final long ACCESS_TOKEN_MAX_AGE = 1000L * 60 * 60 * 24; // 24시간
+    private static final long REFRESH_TOKEN_MAX_AGE = 1000L * 60 * 60 * 24 * 30; // 30일
+
+    private final Key key;
+
+    public JwtTokenProvider() {
+        this.key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+    }
+
+    public String createAccessToken(long userId) {
+        return createToken(String.valueOf(userId), ACCESS_TOKEN_MAX_AGE);
+    }
+
+    public String createRefreshToken(long userId) {
+        return createToken(String.valueOf(userId), REFRESH_TOKEN_MAX_AGE);
+    }
+
+    public String createToken(String userId, long maxAge) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + maxAge))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserIdFromToken(String token) {
+        return parseClaims(token).getBody().getSubject();
+    }
+
+    public List<String> getRolesFromToken(String token) {
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public int getRefreshTokenMaxAgeInSeconds() {
+        return (int) (REFRESH_TOKEN_MAX_AGE / 1000);
+    }
+}

--- a/src/main/java/FinTo/global/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/FinTo/global/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package FinTo.global.security.userdetails;
+
+import FinTo.domain.member.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    public Long getId() {
+        return member.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new SimpleGrantedAuthority("ROLE_" + member.getRole().name())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+}

--- a/src/main/java/FinTo/global/security/userdetails/CustomUserDetailsService.java
+++ b/src/main/java/FinTo/global/security/userdetails/CustomUserDetailsService.java
@@ -1,0 +1,22 @@
+package FinTo.global.security.userdetails;
+
+import FinTo.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findById(Long.valueOf(username))
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- #3 

## 변경 사항

- JWT 관련 클래스 및 필터 추가
- 공통 에러 응답 및 글로벌 핸들러 추가 (이후 BaseException을 상속 받아 에러 처리)

- `DevInitializer` 클래스를 통해 dev 프로필로 실행 시 개발용 멤버 생성 및 엑세스 토큰 자동 발급하도록 구현
  <img width="1043" height="101" alt="image" src="https://github.com/user-attachments/assets/bde3acd8-b5bf-46fa-9986-ad51a2ece25c" />

- 인증이 없는 경우와 실패한 경우 에러 응답 메시지 구별

  - 성공:
  <img width="771" height="504" alt="image" src="https://github.com/user-attachments/assets/84005ed2-ea9d-4164-afe7-3d26c4ed6f9f" />
  
  - 인증 없음:
  <img width="771" height="504" alt="image" src="https://github.com/user-attachments/assets/c6dba104-565b-4ef9-b3a3-24a013c4d6c1" />
  
  
  - 인증 실패:
  <img width="771" height="504" alt="image" src="https://github.com/user-attachments/assets/0089821e-15ca-47ba-bdc7-8d163d8ae0d9" />

## 고려 사항

- 현재 Member가 ID 말고는 유니크 식별자가 없어서 대충 name="dev"로 개발용 계정을 생성하는데, 그럴 일은 잘 없겠지만 "dev" 씨가 개발 DB에 두 명이면 충돌 날 수 있음.  -> 멤버별 유니크 식별자 필요
- 시간 나면 테스트 코드 추가