### PR TITLE
[FEATURE #16]: 화상채팅 + 실시간 채팅 서버 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	//websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/FinTo/domain/calendar/domain/Calendar.java
+++ b/src/main/java/FinTo/domain/calendar/domain/Calendar.java
@@ -1,0 +1,4 @@
+package FinTo.domain.calendar.domain;
+
+public class Calendar {
+}

--- a/src/main/java/FinTo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/FinTo/domain/calendar/service/CalendarService.java
@@ -1,0 +1,4 @@
+package FinTo.domain.calendar.service;
+
+public interface CalendarService {
+}

--- a/src/main/java/FinTo/domain/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/FinTo/domain/calendar/service/CalendarServiceImpl.java
@@ -1,0 +1,4 @@
+package FinTo.domain.calendar.service;
+
+public class CalendarServiceImpl {
+}

--- a/src/main/java/FinTo/domain/mentor/domain/Mentor.java
+++ b/src/main/java/FinTo/domain/mentor/domain/Mentor.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentor.domain;
+
+public class Mentor {
+}

--- a/src/main/java/FinTo/domain/mentoring/controller/MentoringController.java
+++ b/src/main/java/FinTo/domain/mentoring/controller/MentoringController.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.controller;
+
+public class MentoringController {
+}

--- a/src/main/java/FinTo/domain/mentoring/domain/Mentoring.java
+++ b/src/main/java/FinTo/domain/mentoring/domain/Mentoring.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.domain;
+
+public class Mentoring {
+}

--- a/src/main/java/FinTo/domain/mentoring/domain/MentoringDay.java
+++ b/src/main/java/FinTo/domain/mentoring/domain/MentoringDay.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.domain;
+
+public class MentoringDay {
+}

--- a/src/main/java/FinTo/domain/mentoring/domain/MentoringMeeting.java
+++ b/src/main/java/FinTo/domain/mentoring/domain/MentoringMeeting.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.domain;
+
+public class MentoringMeeting {
+}

--- a/src/main/java/FinTo/domain/mentoring/domain/MentoringTime.java
+++ b/src/main/java/FinTo/domain/mentoring/domain/MentoringTime.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.domain;
+
+public class MentoringTime {
+}

--- a/src/main/java/FinTo/domain/mentoring/repository/MentoringRepository.java
+++ b/src/main/java/FinTo/domain/mentoring/repository/MentoringRepository.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.repository;
+
+public interface MentoringRepository {
+}

--- a/src/main/java/FinTo/domain/mentoring/service/MentoringService.java
+++ b/src/main/java/FinTo/domain/mentoring/service/MentoringService.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.service;
+
+public interface MentoringService {
+}

--- a/src/main/java/FinTo/domain/mentoring/service/MentoringServiceImpl.java
+++ b/src/main/java/FinTo/domain/mentoring/service/MentoringServiceImpl.java
@@ -1,0 +1,4 @@
+package FinTo.domain.mentoring.service;
+
+public class MentoringServiceImpl {
+}

--- a/src/main/java/FinTo/domain/review/controller/ReviewController.java
+++ b/src/main/java/FinTo/domain/review/controller/ReviewController.java
@@ -1,0 +1,4 @@
+package FinTo.domain.review.controller;
+
+public class ReviewController {
+}

--- a/src/main/java/FinTo/domain/review/domain/Review.java
+++ b/src/main/java/FinTo/domain/review/domain/Review.java
@@ -1,0 +1,4 @@
+package FinTo.domain.review.domain;
+
+public class Review {
+}

--- a/src/main/java/FinTo/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/FinTo/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,4 @@
+package FinTo.domain.review.repository;
+
+public interface ReviewRepository {
+}

--- a/src/main/java/FinTo/domain/review/service/ReviewService.java
+++ b/src/main/java/FinTo/domain/review/service/ReviewService.java
@@ -1,0 +1,4 @@
+package FinTo.domain.review.service;
+
+public interface ReviewService {
+}

--- a/src/main/java/FinTo/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/FinTo/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,4 @@
+package FinTo.domain.review.service;
+
+public class ReviewServiceImpl {
+}

--- a/src/main/java/FinTo/global/config/chat/SignalingChatHandler.java
+++ b/src/main/java/FinTo/global/config/chat/SignalingChatHandler.java
@@ -1,0 +1,92 @@
+package FinTo.global.config.chat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class SignalingChatHandler extends TextWebSocketHandler {
+
+    // 현재는 사용자 연결에 대한 정보를 (A,B가 화상채팅 중임) 서버 메모리 세션상에서 관리하고있음.
+    // websocket CORS 설정해야함
+    // websocket은 HTTP 헤더에 Authentication 객체 못담아보내는 상황
+    private final Set<WebSocketSession> sessions = ConcurrentHashMap.newKeySet();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 연결 되면
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        sessions.add(session);
+        log.info("Client connected: {}", session.getId());
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+
+        try {
+            // JSON 파싱
+            JsonNode data = objectMapper.readTree(payload);
+            String messageType = data.get("type").asText();
+
+            log.info("Received message type: {} from session: {}", messageType, session.getId());
+
+            // 메시지 타입에 따른 처리 (필요시 확장 가능)
+            switch (messageType) {
+                // WebRTC 연결 제안, 응답, ICE 처리입니다.
+                case "offer":
+                case "answer":
+                case "ice":
+                // websocket 채팅 메시지 처리입니다.
+                case "chat":
+                    broadcastToOthers(session, payload);
+                    break;
+                default:
+                    log.warn("Unknown message type: {}", messageType);
+                    broadcastToOthers(session, payload);
+                    break;
+            }
+
+        } catch (Exception e) {
+            log.error("Invalid JSON or processing error: {}", e.getMessage());
+        }
+    }
+
+    private void broadcastToOthers(WebSocketSession sender, String message) {
+        sessions.stream()
+                .filter(session -> !session.equals(sender) && session.isOpen())
+                .forEach(session -> {
+                    try {
+                        session.sendMessage(new TextMessage(message));
+                    } catch (IOException e) {
+                        log.error("Failed to send message to session {}: {}",
+                                session.getId(), e.getMessage());
+                        // 연결이 끊어진 세션은 제거
+                        sessions.remove(session);
+                    }
+                });
+    }
+
+    // 연결 끊기면
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        sessions.remove(session);
+        log.info("Client disconnected: {}, status: {}", session.getId(), status);
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        sessions.remove(session);
+        log.error("Transport error for session {}: {}", session.getId(), exception.getMessage());
+    }
+}

--- a/src/main/java/FinTo/global/config/chat/WebSocketConfig.java
+++ b/src/main/java/FinTo/global/config/chat/WebSocketConfig.java
@@ -1,0 +1,16 @@
+package FinTo.global.config.chat;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketConfigurer {
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(new SignalingChatHandler(), "/signaling")
+                .setAllowedOrigins("*"); // 개발 환경용, 프로덕션에서는 구체적으로 설정
+    }
+}

--- a/src/main/java/FinTo/global/security/SecurityConfig.java
+++ b/src/main/java/FinTo/global/security/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                                 "/error",
                                 "/auth/**",
                                 "/test/anonymous",
-                                "/actuator/health"
+                                "/actuator/health",
+                                "/signaling"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 관련 이슈

- #16 

## 변경 사항

- 순수 웹소켓 기반의 시그널링 채널로써 백엔드 서버 활용
- 프론트엔드 단에서 사용자가 connection 요청시 백엔드에서는 해당 정보를 메모리에 SET 자료구조를 통해 관리

## 고려 사항

- websocket CORS 설정 필요할수도
- websocket 기반이라 헤더에 인증정보 포함 불가능 + 프론트엔드 단에서 명확한 시나리오가 아직 완성이 안되어서 일단 '되도록'구현
- 서버 메모리에서 관리하기때문에 서버 부하 예상